### PR TITLE
Solving the problem of the null parameter in the str_contains function

### DIFF
--- a/src/Swagger.php
+++ b/src/Swagger.php
@@ -78,7 +78,7 @@ class Swagger {
             if ($filter_route) {
                 if (is_string($route->getAction('controller'))) {
                     $uri = '/' . $route->uri();
-                    if (str_contains($uri, $version)) {
+                    if (is_null($version) || str_contains($uri, $version)) {
                         $prefix = $route->getPrefix();
                         $action = ltrim($route->getActionName(), '\\');
                         $controller = $this->getControllerName($route->getAction('controller'));


### PR DESCRIPTION
Solving the problem of the null parameter in the str_contains function (null parameter #2 is deprecated in php 8.0)

`local.WARNING: str_contains(): Passing null to parameter #2 ($needle) of type string is deprecated`